### PR TITLE
SeaORM 초기 테이블 migration 정의

### DIFF
--- a/morutine-infra/Cargo.toml
+++ b/morutine-infra/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 sea-orm = { version = "1.1.19", features = ["runtime-tokio-rustls", "macros", "sqlx-postgres", "chrono"] }
+sea-orm-migration = { version = "1.1.19", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1"

--- a/morutine-infra/src/database/postgres/migration/init_tables.rs
+++ b/morutine-infra/src/database/postgres/migration/init_tables.rs
@@ -1,0 +1,228 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // 1. users 테이블
+        manager
+            .create_table(
+                Table::create()
+                    .table(Users::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Users::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Users::Nickname).string().not_null())
+                    .col(ColumnDef::new(Users::ProfileImageUrl).string().null())
+                    .col(
+                        ColumnDef::new(Users::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(Users::ModifiedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // 2. social_accounts 테이블
+        manager
+            .create_table(
+                Table::create()
+                    .table(SocialAccounts::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(SocialAccounts::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(SocialAccounts::UserId)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SocialAccounts::Provider).string().not_null())
+                    .col(
+                        ColumnDef::new(SocialAccounts::ProviderUserId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SocialAccounts::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(SocialAccounts::ModifiedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-social_accounts-user_id")
+                            .from(SocialAccounts::Table, SocialAccounts::UserId)
+                            .to(Users::Table, Users::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // 3. todos 테이블
+        manager
+            .create_table(
+                Table::create()
+                    .table(Todos::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Todos::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Todos::UserId).big_integer().not_null())
+                    .col(ColumnDef::new(Todos::Date).date().not_null())
+                    .col(
+                        ColumnDef::new(Todos::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(Todos::ModifiedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-todos-user_id")
+                            .from(Todos::Table, Todos::UserId)
+                            .to(Users::Table, Users::Id),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // 4. todo_items 테이블
+        manager
+            .create_table(
+                Table::create()
+                    .table(TodoItems::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TodoItems::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(TodoItems::TodoId).big_integer().not_null())
+                    .col(ColumnDef::new(TodoItems::Content).string().not_null())
+                    .col(ColumnDef::new(TodoItems::Status).string().not_null())
+                    .col(ColumnDef::new(TodoItems::AlteredContent).string().null())
+                    .col(ColumnDef::new(TodoItems::ImageUrl).string().null())
+                    .col(
+                        ColumnDef::new(TodoItems::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(TodoItems::ModifiedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-todo_items-todo_id")
+                            .from(TodoItems::Table, TodoItems::TodoId)
+                            .to(Todos::Table, Todos::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(TodoItems::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Todos::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(SocialAccounts::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Users::Table).to_owned())
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum Users {
+    Table,
+    Id,
+    Nickname,
+    ProfileImageUrl,
+    CreatedAt,
+    ModifiedAt,
+}
+
+#[derive(Iden)]
+enum SocialAccounts {
+    Table,
+    Id,
+    UserId,
+    Provider,
+    ProviderUserId,
+    CreatedAt,
+    ModifiedAt,
+}
+
+#[derive(Iden)]
+enum Todos {
+    Table,
+    Id,
+    UserId,
+    Date,
+    CreatedAt,
+    ModifiedAt,
+}
+
+#[derive(Iden)]
+enum TodoItems {
+    Table,
+    Id,
+    TodoId,
+    Content,
+    Status,
+    AlteredContent,
+    ImageUrl,
+    CreatedAt,
+    ModifiedAt,
+}

--- a/morutine-infra/src/database/postgres/migration/mod.rs
+++ b/morutine-infra/src/database/postgres/migration/mod.rs
@@ -1,0 +1,12 @@
+pub use sea_orm_migration::prelude::*;
+
+mod init_tables;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(init_tables::Migration)]
+    }
+}

--- a/morutine-infra/src/database/postgres/mod.rs
+++ b/morutine-infra/src/database/postgres/mod.rs
@@ -1,2 +1,3 @@
+pub mod migration;
 pub mod todo;
-mod user;
+pub mod user;


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #3

## ☑️ 완료 태스크
- [x] seaORM migration 작성

<br />

## 🔎 PR 내용
#10 작업 중에 만든 API를 테스트하려면 실제 DB 테이블이 필요한데,
테이블을 직접 만들기보다 DB 구조 변경 이력을 코드 레벨로 관리하는 게 낫겠다 판단했습니다.

현재 프로젝트에는 SeaORM을 ORM으로 사용해서 엔티티랑 실제 DB 스키마 간의 불일치를 줄이고 있는데요.
DB 변경 이력도 마찬가지로 SeaORM migration을 활용하기로 했습니다.

그래서 #10 작업 중 다시 #3 브랜치로 돌아와서 migration 작성을 하게 된 거죠.

---

- users
- social_accounts
- todos
- todo_items

각 테이블들의 초기 구조를 정의하고,  up / down 마이그레이션을 작성했습니다.

- `up`  
  - 테이블 생성, 컬럼 정의, 외래 키 설정 등  
  - DB 상태를 앞으로 진행시키는 변경 사항 정의
- `down`  
  - `up`에서 적용된 변경을 되돌리기 위한 롤백 정의
- `Iden` enum  
  - 테이블/컬럼 이름을 문자열 대신 enum으로 관리해서,
    컴파일 타임에 식별자 오류를 방지하고 SeaORM DSL과 자연스럽게 연동되도록 구성
<br />

이번 PR에서는 마이그레이션 작성까지만 다루고, 
애플리케이션 실행 시 실제 마이그레이션을 수행하는 로직은 추가하지 않았는데요.

#10 브랜치 작업 중에 의존성 주입 + state 흐름 정리로 `state.rs`가 많이 바뀌어서
충돌을 피하려고 #10 브랜치에서 이번 PR 내용 받아온 뒤에 추가하려 합니다.

<br />

## 📷 스크린샷
### `Iden` 식별자 정의
<img width="800" alt="image" src="https://github.com/user-attachments/assets/0865e2a9-d038-447f-b85b-66fb39e262a3" />

### `up` 마이그레이션
<img width="800" alt="image" src="https://github.com/user-attachments/assets/2bf30b84-18c7-48a6-a12c-4d026f9e2227" />

### `down` 마이그레이션
<img width="800" alt="image" src="https://github.com/user-attachments/assets/41b4229f-0a78-4013-98fb-bed0cba749ab" />
